### PR TITLE
fix: 불필요한 양방향 관계 삭제

### DIFF
--- a/src/main/java/com/cona/projectcona/User/User.java
+++ b/src/main/java/com/cona/projectcona/User/User.java
@@ -33,17 +33,5 @@ public class User {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private ProfileImage profileImage;
 
-    @OneToMany(mappedBy = "user")
-    private List<PinPlace> pinPlaces = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user")
-    private List<Review> reviews = new ArrayList<>();
-
     private LocalDateTime signedAt;
-
-    @OneToMany(mappedBy = "follower", targetEntity = Follow.class)
-    private List<User> followers = new ArrayList<>();
-
-    @OneToMany(mappedBy ="following", targetEntity = Follow.class)
-    private List<User> following = new ArrayList<>();
 }


### PR DESCRIPTION
삭제한 양방향 관계들은 모두 해당 엔티티의 레포지토리에서 관리(CRUD)를 하는 것이 SRP(단일 책임 원칙)를 더 잘 지키는 패턴이라고 판단